### PR TITLE
Handling of datatypes other then string

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,37 +73,32 @@ On CentOS both files are combined in `/etc/httpd/conf.modules.d/02-gelf.conf`
 
 What does the `GelfFields` string mean:
 
-| Character | Logging information |
-|-----------|---------------------|
-| A         | Agent string        |
-| a         | Request arguments   |
-| B         | Bytes send          |
-| C         | Connection status   |
-| c         | Extract Cookie      |
-|           | (name must be in    |
-|           | GelfCookie)         |
-| D         | Request duration    |
-|           | (in microseconds)   |
-| f         | Requested file      |
-| H         | Protocol            |
-| h         | Remote host         |
-| i         | Remote address      |
-| L         | Local address       |
-| l         | Auth login name     |
-| m         | Request methode     |
-| p         | Server port         |
-| P         | Child PID           |
-| R         | Referer             |
-| r         | Request string      |
-| s         | Return status       |
-| t         | Request timestamp   |
-| U         | Request URI         |
-| u         | Username            |
-| V         | Server name         |
-| v         | VirtualHost name    |
-| X         | Extract Header      |
-|           | (name must be in    |
-|           | GelfHeader)         |
+| Character | Logging information                         |
+|-----------|---------------------------------------------|
+| A         | Agent string                                |
+| a         | Request arguments                           |
+| B         | Bytes send                                  |
+| C         | Connection status                           |
+| c         | Extract Cookie (name must be in GelfCookie) |
+| D         | Request duration (in microseconds)          |
+| f         | Requested file                              |
+| H         | Protocol                                    |
+| h         | Remote host                                 |
+| i         | Remote address                              |
+| L         | Local address                               |
+| l         | Auth login name                             |
+| m         | Request methode                             |
+| p         | Server port                                 |
+| P         | Child PID                                   |
+| R         | Referer                                     |
+| r         | Request string                              |
+| s         | Return status                               |
+| t         | Request timestamp                           |
+| U         | Request URI                                 |
+| u         | Username                                    |
+| V         | Server name                                 |
+| v         | VirtualHost name                            |
+| X         | Extract Header (name must be in GelfHeader) |
 
 # Packages
 

--- a/README.md
+++ b/README.md
@@ -60,16 +60,16 @@ Configure the module in `/etc/apache2/mods-enabled/log_gelf.conf`:
 ```
 On CentOS both files are combined in `/etc/httpd/conf.modules.d/02-gelf.conf`
 
-| Parameter    | Argument               | Description                                        |
-|--------------|------------------------|----------------------------------------------------|
-| GelfEnabled  | On/Off                 | Load GELF logging module                           |
-| GelfUrl      | Graylog server URL     | Set IP and port of a UDP GELF input                |
-| GelfSource   | (Optional)             | Overwrite source field                             |
-| GelfFacility | (Optional)             | Overwrite logging facility                         |
-| GelfTag      | (Optional)             | Add a `tag` field to every log message             |
-| GelfCookie   | (Optional) cookie name | Extract cookie from web request, Use 'c' GelfField |
-| GelfHeader   | (Optional) header name | Extract header from web request, Use 'X' GelfField |
-| GelfFields   | (Optional)             | Configures which information should be logged      |
+| Parameter    | Argument               | Description                                            |
+|--------------|------------------------|--------------------------------------------------------|
+| GelfEnabled  | On/Off                 | Load GELF logging module                               |
+| GelfUrl      | Graylog server URL     | Set IP and port of a UDP GELF input                    |
+| GelfSource   | (Optional)             | Overwrite source field                                 |
+| GelfFacility | (Optional)             | Overwrite logging facility                             |
+| GelfTag      | (Optional)             | Add a `tag` field to every log message                 |
+| GelfCookie   | (Optional) cookie name | Extract one cookie from web request, Use 'c' GelfField |
+| GelfHeader   | (Optional) header name | Extract one header from web request, Use 'X' GelfField |
+| GelfFields   | (Optional)             | Configures which information should be logged          |
 
 What does the `GelfFields` string mean:
 
@@ -80,6 +80,8 @@ What does the `GelfFields` string mean:
 | B         | Bytes send          |
 | C         | Connection status   |
 | c         | Extract Cookie      |
+|           | (name must be in    |
+|           | GelfCookie)         |
 | D         | Request duration    |
 |           | (in microseconds)   |
 | f         | Requested file      |
@@ -100,6 +102,8 @@ What does the `GelfFields` string mean:
 | V         | Server name         |
 | v         | VirtualHost name    |
 | X         | Extract Header      |
+|           | (name must be in    |
+|           | GelfHeader)         |
 
 # Packages
 

--- a/src/functions.h
+++ b/src/functions.h
@@ -3,14 +3,14 @@
  * value to the calling entity.
  */
 
-static const json_object *extract_remote_host(request_rec *r, char *a)
+json_object *extract_remote_host(request_rec *r, char *a)
 {
 	return json_object_new_string(ap_get_remote_host(r->connection, r->per_dir_config, REMOTE_NAME, NULL));
 }
 
-static const json_object *extract_remote_address(request_rec *r, char *a) __attribute__((unused));
+json_object *extract_remote_address(request_rec *r, char *a) __attribute__((unused));
 
-static const json_object *extract_remote_address(request_rec *r, char *a)
+json_object *extract_remote_address(request_rec *r, char *a)
 {
     #ifdef WITH_APACHE22
     return json_object_new_string(r->connection->remote_ip);
@@ -19,14 +19,14 @@ static const json_object *extract_remote_address(request_rec *r, char *a)
     #endif
 }
 
-static const json_object *extract_local_address(request_rec *r, char *a) __attribute__((unused));
+json_object *extract_local_address(request_rec *r, char *a) __attribute__((unused));
 
-static const json_object *extract_local_address(request_rec *r, char *a)
+json_object *extract_local_address(request_rec *r, char *a)
 {
     return json_object_new_string(r->connection->local_ip);
 }
 
-static const json_object *extract_remote_logname(request_rec *r, char *a)
+json_object *extract_remote_logname(request_rec *r, char *a)
 {
   const char *rlogin = ap_get_remote_logname(r);
   if (rlogin == NULL) {
@@ -38,7 +38,7 @@ static const json_object *extract_remote_logname(request_rec *r, char *a)
 	return json_object_new_string(rlogin);
 }
 
-static const json_object *extract_remote_user(request_rec *r, char *a)
+json_object *extract_remote_user(request_rec *r, char *a)
 {
 	#ifdef WITH_APACHE13
 	char *rvalue = r->connection->user;
@@ -53,7 +53,7 @@ static const json_object *extract_remote_user(request_rec *r, char *a)
 	return json_object_new_string(rvalue);
 }
 
-static const json_object *extract_request_line(request_rec *r, char *a)
+json_object *extract_request_line(request_rec *r, char *a)
 {
 	/* Upddated to mod_log_config logic */
 	/* NOTE: If the original request contained a password, we
@@ -71,34 +71,34 @@ static const json_object *extract_request_line(request_rec *r, char *a)
 				: r->the_request);
 }
 
-static const json_object *extract_request_file(request_rec *r, char *a)
+json_object *extract_request_file(request_rec *r, char *a)
 {
 	return json_object_new_string(r->filename);
 }
 
-static const json_object *extract_request_uri(request_rec *r, char *a)
+json_object *extract_request_uri(request_rec *r, char *a)
 {
 	return json_object_new_string(r->uri);
 }
 
-static const json_object *extract_request_method(request_rec *r, char *a)
+json_object *extract_request_method(request_rec *r, char *a)
 {
 	return json_object_new_string(r->method);
 }
 
-static const json_object *extract_request_protocol(request_rec *r, char *a)
+json_object *extract_request_protocol(request_rec *r, char *a)
 {
 	return json_object_new_string(r->protocol);
 }
 
-static const json_object *extract_request_query(request_rec *r, char *a)
+json_object *extract_request_query(request_rec *r, char *a)
 {
 	return json_object_new_string((r->args) ? apr_pstrcat(r->pool, "?",
 						r->args, NULL)
 					 : "");
 }
 
-static const json_object *extract_status(request_rec *r, char *a)
+json_object *extract_status(request_rec *r, char *a)
 {
 	if (r->status <= 0) {
 		return NULL;
@@ -107,17 +107,17 @@ static const json_object *extract_status(request_rec *r, char *a)
 	}
 }
 
-static const json_object *extract_virtual_host(request_rec *r, char *a)
+json_object *extract_virtual_host(request_rec *r, char *a)
 {
     return json_object_new_string(r->server->server_hostname);
 }
 
-static const json_object *extract_server_name(request_rec *r, char *a)
+json_object *extract_server_name(request_rec *r, char *a)
 {
     return json_object_new_string(ap_get_server_name(r));
 }
 
-static const json_object *extract_server_port(request_rec *r, char *a)
+json_object *extract_server_port(request_rec *r, char *a)
 {
     return json_object_new_string(apr_psprintf(r->pool, "%u",
                         r->server->port ? r->server->port : ap_default_port(r)));
@@ -132,7 +132,7 @@ static const char *log_server_name(request_rec *r, char *a)
     return ap_get_server_name(r);
 }
 
-static const json_object *extract_child_pid(request_rec *r, char *a)
+json_object *extract_child_pid(request_rec *r, char *a)
 {
     if (*a == '\0' || !strcmp(a, "pid")) {
         return json_object_new_string(apr_psprintf(r->pool, "%" APR_PID_T_FMT, getpid()));
@@ -149,7 +149,7 @@ static const json_object *extract_child_pid(request_rec *r, char *a)
     return json_object_new_string(a);
 }
 
-static const json_object *extract_header(request_rec *r, char *a)
+json_object *extract_header(request_rec *r, char *a)
 {
 	const char *tempref;
 
@@ -162,7 +162,7 @@ static const json_object *extract_header(request_rec *r, char *a)
 	}
 }
 
-static const json_object *extract_referer(request_rec *r, char *a)
+json_object *extract_referer(request_rec *r, char *a)
 {
 	const char *tempref;
 
@@ -175,7 +175,7 @@ static const json_object *extract_referer(request_rec *r, char *a)
 	}
 }
 
-static const json_object *extract_agent(request_rec *r, char *a)
+json_object *extract_agent(request_rec *r, char *a)
 {
     const char *tempag;
 
@@ -188,7 +188,7 @@ static const json_object *extract_agent(request_rec *r, char *a)
     }
 }
 
-static const json_object *extract_specific_cookie(request_rec *r, char *a)
+json_object *extract_specific_cookie(request_rec *r, char *a)
 {
   const char *cookiestr;
   char *cookieend;

--- a/src/functions20.h
+++ b/src/functions20.h
@@ -1,19 +1,19 @@
-static const char *extract_bytes_sent(request_rec *r, char *a)
+static const json_object *extract_bytes_sent(request_rec *r, char *a)
 {
 	if (!r->sent_bodyct || !r->bytes_sent) {
-		return "-";
+		return NULL;
 	} else {
-		return apr_psprintf(r->pool, "%" APR_OFF_T_FMT, r->bytes_sent);
+		return json_object_new_int(r->bytes_sent);
 	}
 }
 
-static const char *extract_request_time_custom(request_rec *r, char *a,
+static const json_object *extract_request_time_custom(request_rec *r, char *a,
                                            apr_time_exp_t *xt)
 {
     apr_size_t retcode;
     char tstr[MAX_STRING_LEN];
     apr_strftime(tstr, &retcode, sizeof(tstr), a, xt);
-    return apr_pstrdup(r->pool, tstr);
+    return json_object_new_string(apr_pstrdup(r->pool, tstr));
 }
 
 #define DEFAULT_REQUEST_TIME_SIZE 32
@@ -27,7 +27,7 @@ typedef struct {
 #define TIME_CACHE_MASK 3
 static cached_request_time request_time_cache[TIME_CACHE_SIZE];
 
-static const char *extract_request_time(request_rec *r, char *a)
+static const json_object *extract_request_time(request_rec *r, char *a)
 {
 	apr_time_exp_t xt;
 
@@ -78,26 +78,26 @@ static const char *extract_request_time(request_rec *r, char *a)
             memcpy(&(request_time_cache[i]), cached_time,
                    sizeof(*cached_time));
 		}
-		return cached_time->timestr;
+		return json_object_new_string(cached_time->timestr);
 	}
 }
 
-static const char *extract_request_duration(request_rec *r, char *a)
+static const json_object *extract_request_duration(request_rec *r, char *a)
 {
 	apr_time_t duration = apr_time_now() - r->request_time;
-	return apr_psprintf(r->pool, "%ld", apr_time_usec(duration));
+	return json_object_new_int(apr_time_usec(duration));
 }
 
-static const char *extract_connection_status(request_rec *r, char *a) __attribute__((unused));
-static const char *extract_connection_status(request_rec *r, char *a)
+static const json_object *extract_connection_status(request_rec *r, char *a) __attribute__((unused));
+static const json_object *extract_connection_status(request_rec *r, char *a)
 {
     if (r->connection->aborted)
-        return "X";
+        return json_object_new_string("X");
 
     if (r->connection->keepalive == AP_CONN_KEEPALIVE &&
         (!r->server->keep_alive_max ||
          (r->server->keep_alive_max - r->connection->keepalives) > 0)) {
-        return "+";
+        return json_object_new_string("+");
     }
-    return "-";
+    return NULL;
 }

--- a/src/functions20.h
+++ b/src/functions20.h
@@ -1,4 +1,4 @@
-static const json_object *extract_bytes_sent(request_rec *r, char *a)
+json_object *extract_bytes_sent(request_rec *r, char *a)
 {
 	if (!r->sent_bodyct || !r->bytes_sent) {
 		return NULL;
@@ -7,7 +7,7 @@ static const json_object *extract_bytes_sent(request_rec *r, char *a)
 	}
 }
 
-static const json_object *extract_request_time_custom(request_rec *r, char *a,
+json_object *extract_request_time_custom(request_rec *r, char *a,
                                            apr_time_exp_t *xt)
 {
     apr_size_t retcode;
@@ -27,7 +27,7 @@ typedef struct {
 #define TIME_CACHE_MASK 3
 static cached_request_time request_time_cache[TIME_CACHE_SIZE];
 
-static const json_object *extract_request_time(request_rec *r, char *a)
+json_object *extract_request_time(request_rec *r, char *a)
 {
 	apr_time_exp_t xt;
 
@@ -82,14 +82,14 @@ static const json_object *extract_request_time(request_rec *r, char *a)
 	}
 }
 
-static const json_object *extract_request_duration(request_rec *r, char *a)
+json_object *extract_request_duration(request_rec *r, char *a)
 {
 	apr_time_t duration = apr_time_now() - r->request_time;
 	return json_object_new_int(apr_time_usec(duration));
 }
 
-static const json_object *extract_connection_status(request_rec *r, char *a) __attribute__((unused));
-static const json_object *extract_connection_status(request_rec *r, char *a)
+json_object *extract_connection_status(request_rec *r, char *a) __attribute__((unused));
+json_object *extract_connection_status(request_rec *r, char *a)
 {
     if (r->connection->aborted)
         return json_object_new_string("X");

--- a/src/mod_log_gelf.c
+++ b/src/mod_log_gelf.c
@@ -457,7 +457,8 @@ char * log_gelf_make_json(request_rec *request) {
   /* attach field pairs to json root */
   json_add_string(object, "version", "1.1");
   json_add_string(object, "host", config->source);
-  json_add_string(object, "short_message", extract_request_line(request, NULL));
+  // json_add_string(object, "short_message", extract_request_line(request, NULL));
+  json_object_object_add(object, "short_message", extract_request_line(request, NULL));
   json_add_string(object, "facility", config->facility);
   json_add_int(object, "level", 6); /*0=Emerg, 1=Alert, 2=Crit, 3=Error, 4=Warn, 5=Notice, 6=Info */
   json_add_double(object, "timestamp", log_gelf_get_timestamp());
@@ -466,11 +467,13 @@ char * log_gelf_make_json(request_rec *request) {
   length = strlen(config->fields);
   for (i = 0; i<length; i++) {
     log_item *item = config->parsed_fields[i];
+    json_object* fval;
     if (item != NULL) {
-      if (item->arg)
-        json_add_string(object, item->field_name, item->func(request, (char*)item->arg));
-      else
-        json_add_string(object, item->field_name, item->func(request, ""));
+      fval = item->func(request, (char*)item->arg);
+      if (fval != NULL) {
+	json_object_object_add(object, item->field_name, fval);
+      }
+
     }
   }
 

--- a/src/mod_log_gelf.c
+++ b/src/mod_log_gelf.c
@@ -30,14 +30,14 @@ static char errbuf[1024];
 
 typedef struct {
   char key;               /* item letter character */
-  item_func  *func;       /* its extraction function */
+  item_func  *extractor_func;       /* its extraction function */
   const char *arg;        /* one string argument for func */
   const char *field_name; /* GELF extra field name */
 } log_item;
 
 typedef struct {
-  apr_socket_t        *s;                 /* Actual GELF connection */
-  apr_sockaddr_t      *sa;                /* GELF Address */
+  apr_socket_t        *gelf_sock;                 /* Actual GELF connection */
+  apr_sockaddr_t      *gelf_addr;                /* GELF Address */
 } gelf_connection;
 
 typedef struct {
@@ -95,7 +95,7 @@ void log_gelf_register_item(server_rec *server, apr_pool_t *p,
 
   item = apr_array_push(log_item_list);
   item->key = key;
-  item->func = func;
+  item->extractor_func = func;
   item->field_name = field_name;
   if (arg)
     item->arg = arg;
@@ -248,21 +248,21 @@ static apr_status_t log_gelf_get_gelf_connection(gelf_connection *gc, gelf_confi
       "mod_log_gelf: Connecting to server: %s", config->server);
   }
 
-  rv = apr_sockaddr_info_get(&gc->sa, config->server, APR_INET, config->port, 0, pool);
+  rv = apr_sockaddr_info_get(&gc->gelf_addr, config->server, APR_INET, config->port, 0, pool);
   if (rv != APR_SUCCESS) {
     ap_log_perror(APLOG_MARK, APLOG_ERR, 0, pool,
       "mod_log_gelf: Error setting GELF recipient %s:%d", config->server, config->port);
     return rv;
   }
 
-  rv = apr_socket_create(&gc->s, gc->sa->family, type, proto, pool);
+  rv = apr_socket_create(&gc->gelf_sock, gc->gelf_addr->family, type, proto, pool);
   if (rv != APR_SUCCESS) {
     ap_log_perror(APLOG_MARK, APLOG_ERR, 0, pool,
       "mod_log_gelf: Error opening GELF socket: %s", apr_strerror(rv, errbuf, sizeof(errbuf)));
     return rv;
   }
 
-  rv = apr_socket_connect(gc->s, gc->sa);
+  rv = apr_socket_connect(gc->gelf_sock, gc->gelf_addr);
   if (rv != APR_SUCCESS) {
     ap_log_perror(APLOG_MARK, APLOG_ERR, 0, pool,
       "mod_log_gelf: Error connecting to GELF port: %s", apr_strerror(rv, errbuf, sizeof(errbuf)));
@@ -270,7 +270,7 @@ static apr_status_t log_gelf_get_gelf_connection(gelf_connection *gc, gelf_confi
   }
 
   /* set socket options */
-  rv = apr_socket_opt_set(gc->s, APR_SO_SNDBUF, SEND_BUFFER);
+  rv = apr_socket_opt_set(gc->gelf_sock, APR_SO_SNDBUF, SEND_BUFFER);
   if (rv != APR_SUCCESS) {
     ap_log_perror(APLOG_MARK, APLOG_ERR, 0, pool,
       "mod_log_gelf: Error setting send buffer: %s", apr_strerror(rv, errbuf, sizeof(errbuf)));
@@ -279,21 +279,21 @@ static apr_status_t log_gelf_get_gelf_connection(gelf_connection *gc, gelf_confi
 
   if (config->protocol == TCP) {
     /* TCP socket options */
-    rv = apr_socket_opt_set(gc->s, APR_SO_NONBLOCK, 0);
+    rv = apr_socket_opt_set(gc->gelf_sock, APR_SO_NONBLOCK, 0);
     if (rv != APR_SUCCESS) {
       ap_log_perror(APLOG_MARK, APLOG_ERR, 0, pool,
         "mod_log_gelf: Error setting socket to blocking: %s", apr_strerror(rv, errbuf, sizeof(errbuf)));
       return rv;
     }
 
-    rv = apr_socket_opt_set(gc->s, APR_TCP_NODELAY, 1);
+    rv = apr_socket_opt_set(gc->gelf_sock, APR_TCP_NODELAY, 1);
     if (rv != APR_SUCCESS) {
       ap_log_perror(APLOG_MARK, APLOG_ERR, 0, pool,
         "mod_log_gelf: Error setting socket TCP nodelay: %s", apr_strerror(rv, errbuf, sizeof(errbuf)));
       return rv;
     }
 
-    rv = apr_socket_timeout_set(gc->s, 0);
+    rv = apr_socket_timeout_set(gc->gelf_sock, 0);
     if (rv != APR_SUCCESS) {
       ap_log_perror(APLOG_MARK, APLOG_ERR, 0, pool,
         "mod_log_gelf: Error setting socket timeout: %s", apr_strerror(rv, errbuf, sizeof(errbuf)));
@@ -340,7 +340,7 @@ static apr_status_t gelf_pool_destruct(void* resource, void* params, apr_pool_t*
       ap_log_perror(APLOG_MARK, APLOG_CRIT, 0, pool, "mod_log_gelf: Removing socket from pool");
     }
     gelf_connection *con = (gelf_connection*)resource;
-    apr_socket_close(con->s);
+    apr_socket_close(con->gelf_sock);
   }
   return APR_SUCCESS ;
 }
@@ -469,7 +469,7 @@ char * log_gelf_make_json(request_rec *request) {
     log_item *item = config->parsed_fields[i];
     json_object* fval;
     if (item != NULL) {
-      fval = item->func(request, (char*)item->arg);
+      fval = item->extractor_func(request, (char*)item->arg);
       if (fval != NULL) {
 	json_object_object_add(object, item->field_name, fval);
       }
@@ -580,7 +580,7 @@ void log_gelf_send_message_udp(const transferData* payload, request_rec *request
       "mod_log_gelf: Sending GELF message: %s", (char*)payload->data);
   }
 
-  rv = apr_socket_send(con->s, payload->data, &len);
+  rv = apr_socket_send(con->gelf_sock, payload->data, &len);
   if (rv != APR_SUCCESS) {
     log_error(APLOG_MARK, APLOG_ERR, 0, request->server,
       "mod_log_gelf: Error writing to socket %d bytes. Error %s",
@@ -609,7 +609,7 @@ void log_gelf_send_message_tcp(const transferData* payload, request_rec *request
 
   /* acquire a free socket, send message, release socket */
   gelf_connection *con = log_gelf_connection_acquire(request);
-  if (!con || !con->s) {
+  if (!con || !con->gelf_sock) {
     return;
   }
 
@@ -618,7 +618,7 @@ void log_gelf_send_message_tcp(const transferData* payload, request_rec *request
       "mod_log_gelf: Sending GELF message: %s", gelf_payload);
   }
 
-  rv = apr_socket_send(con->s, gelf_payload, &len);
+  rv = apr_socket_send(con->gelf_sock, gelf_payload, &len);
   if (rv != APR_SUCCESS) {
     log_error(APLOG_MARK, APLOG_ERR, 0, request->server,
       "mod_log_gelf: Error writing to socket %d bytes. Error %s",

--- a/src/mod_log_gelf.c
+++ b/src/mod_log_gelf.c
@@ -232,8 +232,8 @@ static apr_status_t log_gelf_connection_release(request_rec* r, gelf_connection 
 
 static apr_status_t log_gelf_get_gelf_connection(gelf_connection *gc, gelf_config *config, apr_pool_t *pool) {
   apr_status_t rv;
-  int proto = NULL;
-  int type = NULL;
+  int proto = 0;
+  int type = 0;
 
   if (config->protocol == TCP) {
     proto = APR_PROTO_TCP;

--- a/src/mod_log_gelf.h
+++ b/src/mod_log_gelf.h
@@ -1,4 +1,4 @@
-typedef const char *item_func(request_rec *r, char *a);
+typedef const json_object* item_func(request_rec *r, char *a);
 typedef struct transferDataS {
     void * data;
     int size;

--- a/src/mod_log_gelf.h
+++ b/src/mod_log_gelf.h
@@ -1,4 +1,4 @@
-typedef const json_object* item_func(request_rec *r, char *a);
+typedef json_object* item_func(request_rec *r, char *a);
 typedef struct transferDataS {
     void * data;
     int size;


### PR DESCRIPTION
I did some small changes to be able to transport field values into the gelf format in their original data type.

The original solution created always json string objects from return value of the extractor functions which were all string. Instead of a more complicated handling of multiple return type I moved the json object creation into the extractor function so I can decide at this place which data type to use. As additional benefit I can now omit empty fields by returning NULL.

Since I was a bit puzzled by the description and how I should use the header and cookie name parameter, I've added some clarification to the doc.

Next step would be more flexibility of the configuration by using a mod_log_config inspired approach with the same placeholders and the ability to return multiple different fields both from request and response.
`%{VARNAME}i`
could be 
`i{Request-Headername}`
which I find nicer to read.

Maybe it makes sense to also be able to change resulting field names and/or define a base name.

Btw I really believe "bytes_send" should be "bytes_sent"?
